### PR TITLE
Feat: Support for monorepo base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,10 @@ smaller-modules --list --file dist/index.js
 ```bash
 smaller-modules --zip --file dist/index.js --output-subdirectory nodejs --output-path node_modules.zip
 ```
+
+## Use with packages in a mono-repository
+
+```bash
+# Run from packages/<package-name>
+smaller-modules --list --file dist/index.js --base "../.." 
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smaller-modules",
-  "version": "0.3.0-alpha.1",
+  "version": "0.3.0",
   "description": "Shrink node_modules for deployment",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smaller-modules",
-  "version": "0.2.4",
+  "version": "0.3.0-alpha.0",
   "description": "Shrink node_modules for deployment",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smaller-modules",
-  "version": "0.3.0-alpha.0",
+  "version": "0.3.0-alpha.1",
   "description": "Shrink node_modules for deployment",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,7 @@ function collect(value: string, previous: string[]) {
 
 const program = new Command();
 program
-  .version("0.3.0-alpha.0")
+  .version("0.3.0-alpha.1")
   .description("Shrink node_modules for deployment")
   .option("-c, --copy", "copy required files to a new directory")
   .option("-l, --list", "output list of required files")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,12 +16,13 @@ function collect(value: string, previous: string[]) {
 
 const program = new Command();
 program
-  .version("0.1.0")
+  .version("0.3.0-alpha.0")
   .description("Shrink node_modules for deployment")
   .option("-c, --copy", "copy required files to a new directory")
   .option("-l, --list", "output list of required files")
   .option("-z, --zip", "output a zip file containing node_modules")
 
+  .option("-b, --base <path/to/base>", "base directory containing all source files")
   .option("-d, --directory <path/to/js>", "input directory for dependency tracing", collect, [])
   .option("-f, --file <filename.js>", "input file for dependency tracing", collect, [])
   .option("-o, --output-path <path/to/build/output>", "output file (list) or directory (copy / zip)")
@@ -38,7 +39,9 @@ if (!opts.copy && !opts.list && !opts.zip) {
   program.outputHelp();
 }
 
-const smaller = new SmallerModules();
+const smaller = new SmallerModules({
+  base: opts.base
+});
 
 if (opts.directory && opts.directory.length > 0) {
   smaller.directories(opts.directory);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,7 @@ function collect(value: string, previous: string[]) {
 
 const program = new Command();
 program
-  .version("0.3.0-alpha.1")
+  .version("0.3.0")
   .description("Shrink node_modules for deployment")
   .option("-c, --copy", "copy required files to a new directory")
   .option("-l, --list", "output list of required files")

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -1,4 +1,6 @@
 import {SmallerModules} from "../src/index";
+import fsExtra from "fs-extra";
+import path from "path";
 
 describe('testing SmallerModules class', () => {
   describe('create list of dependencies from source files', () => {
@@ -37,6 +39,36 @@ describe('testing SmallerModules class', () => {
       await smaller.trace();
       expect(smaller.list()).toContain("dist/index.js");
       expect(smaller.list()).toContain("dist/cli.js");
+    });
+  });
+
+  describe('test base path with complex mono-repo setup', () => {
+    let smaller: SmallerModules;
+    let initialCwd: string;
+    let temporaryPackage = path.join("packages", "temporary");
+    beforeAll(() => {
+      fsExtra.copySync("dist", path.join(temporaryPackage, "dist"));
+      initialCwd = process.cwd();
+      process.chdir(temporaryPackage);
+      smaller = new SmallerModules({
+        base: "../..",
+      });
+    });
+    afterAll(() => {
+      process.chdir(initialCwd);
+      fsExtra.rm(temporaryPackage, {recursive: true, force: true});
+    });
+    test('adding dependencies by directory', () => {
+      smaller
+        .directories(['dist/']);
+    });
+    test('dependencies should be empty before tracing', () => {
+      expect(smaller.list()).toStrictEqual([]);
+    });
+    test('expected files should be present', async () => {
+      await smaller.trace();
+      expect(smaller.list()).toContain(path.join(temporaryPackage, "dist/index.js"));
+      expect(smaller.list()).toContain(path.join(temporaryPackage, "dist/cli.js"));
     });
   });
 });


### PR DESCRIPTION
When compiling a mono-repository, `node_modules/` should also be traced from the workspace root.

This PR adds a new CLI option `--base "../path-to-root" to help with that.
Programmatic use is also supported by specifying the `base` parameter in the `SmallerModules` constructor:
```diff
  const smaller = new SmallerModules({
+   base: "../..",
  });
```